### PR TITLE
[PR #3] Horovod support for NCCL profiling

### DIFF
--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -18,7 +18,6 @@
 #include <stdlib.h>
 #include <thread>
 #include <unordered_map>
-#include <iostream>
 
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"

--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -2062,11 +2062,16 @@ GPU_EVENT_IF_CUDA RecordReadyEvent(OpKernelContext* context) {
 
 ncclProf_t* get_prof_info(OpKernelContext* context, const string name) {
   ncclProf_t* nccl_prof = (ncclProf_t*) malloc(sizeof(ncclProf_t));
+
   nccl_prof->do_profile = true;
 
   const Tensor* global_step = &context->input(1);
   const int64* global_step_ptr = (const int64*) global_step->tensor_data().data();
   nccl_prof->step = *global_step_ptr;
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  nccl_prof->worker_id = rank;
   
   const std::string::size_type size = name.size();
   char* tmp = new char[size + 1];
@@ -2074,7 +2079,9 @@ ncclProf_t* get_prof_info(OpKernelContext* context, const string name) {
   nccl_prof->tensor_name = tmp;
   
   nccl_prof->stat_vector = nullptr;
+
   nccl_prof->saved = 0;
+
   return nccl_prof;
 }
 

--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -1764,8 +1764,6 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
     delete it->second;
   }
 
-  ncclStatCollectorEnd();
-
   // TODO: init.cu:645 WARN Cuda failure 'driver shutting down'
   //#if HAVE_NCCL
   //  for (auto it = horovod_global.streams.begin();
@@ -2061,12 +2059,16 @@ GPU_EVENT_IF_CUDA RecordReadyEvent(OpKernelContext* context) {
 
 } // namespace tensorflow
 
-ncclProf_t* get_prof_info(OpKernelContext* context, const string& name) {
+ncclProf_t* get_prof_info(OpKernelContext* context, const string name) {
   ncclProf_t* nccl_prof = (ncclProf_t*) malloc(sizeof(ncclProf_t));
   nccl_prof->do_profile = true;
   nccl_prof->step = context->step_id();
-  nccl_prof->tensor_name = name;
-  nccl_prof->stat_vector = NULL;
+  const std::string::size_type size = name.size();
+  char* tmp = new char[size + 1];
+  memcpy(tmp, name.c_str(), size + 1);
+  nccl_prof->tensor_name = tmp;
+  nccl_prof->stat_vector = nullptr;
+  nccl_prof->saved = 0;
   return nccl_prof;
 }
 

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -129,7 +129,7 @@ def _normalize_name(name):
     return re.sub('[^a-zA-Z0-9_]', '_', name)
 
 
-def _allreduce(tensor, name=None):
+def _allreduce(tensor, global_step, name=None):
     """An op which sums an input tensor over all the Horovod processes.
 
     The reduction operation is keyed by the name of the op. The tensor type and
@@ -142,13 +142,13 @@ def _allreduce(tensor, name=None):
     """
     if name is None:
         name = 'HorovodAllreduce_%s' % _normalize_name(tensor.name)
-    return MPI_LIB.horovod_allreduce(tensor, name=name)
+    return MPI_LIB.horovod_allreduce(tensor, global_step, name=name)
 
 
 ops.NotDifferentiable('HorovodAllreduce')
 
 
-def allgather(tensor, name=None):
+def allgather(tensor, global_step, name=None):
     """An op which concatenates the input tensor with the same input tensor on
     all other Horovod processes.
 
@@ -163,13 +163,13 @@ def allgather(tensor, name=None):
     """
     if name is None:
         name = 'HorovodAllgather_%s' % _normalize_name(tensor.name)
-    return MPI_LIB.horovod_allgather(tensor, name=name)
+    return MPI_LIB.horovod_allgather(tensor, global_step, name=name)
 
 
 ops.NotDifferentiable('HorovodAllgather')
 
 
-def allgatherv(tensor, name=None):
+def allgatherv(tensor, global_step, name=None):
     """An op which concatenates the input tensor with the same input tensor on
     all other Horovod processes.
 
@@ -185,13 +185,13 @@ def allgatherv(tensor, name=None):
     """
     if name is None:
         name = 'HorovodAllgatherv_%s' % _normalize_name(tensor.name)
-    return MPI_LIB.horovod_allgatherv(tensor, name=name)
+    return MPI_LIB.horovod_allgatherv(tensor, global_step, name=name)
 
 
 ops.NotDifferentiable('HorovodAllgatherv')
 
 
-def broadcast(tensor, root_rank, name=None):
+def broadcast(tensor, global_step, root_rank, name=None):
     """An op which broadcasts the input tensor on root rank to the same input tensor
     on all other Horovod processes.
 
@@ -205,7 +205,7 @@ def broadcast(tensor, root_rank, name=None):
     """
     if name is None:
         name = 'HorovodBroadcast_%s' % _normalize_name(tensor.name)
-    return MPI_LIB.horovod_broadcast(tensor, name=name, root_rank=root_rank)
+    return MPI_LIB.horovod_broadcast(tensor, global_step, name=name, root_rank=root_rank)
 
 
 ops.NotDifferentiable('HorovodBroadcast')


### PR DESCRIPTION
**Major changes:**
Both Horovod and NCCL APIs should be changed to support NCCL communication profiling (Refer new PR in `snuspl/nccl` repo)

Major change for NCCL API is the newly introduced parameter, `nccl_prof`.
Through `nccl_prof` argument, Horovod let NCCL to know _step_, _tensor\_name_, _global\_step_, etc. (see `get_prof_info()`)

To get an information about _global\_step_, now Horovod op kernel receives a `global_step` operation as an input. `global_step` operation should be placed in _HostMemory_ to be read in the op kernel.

**Minor changes to note:**
This PR merges branch `fix_nccl_api` into `EnableNcclProfiling` (not `master` branch).

**Tests for the changes:**
Use `EnableNcclProfiling` branch (after this PR is merged) to profile NCCL communication time.

**Other comments:**
None